### PR TITLE
Add Go 1.11+ module support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/kadekcipta/beanwalker
+
+require (
+	github.com/kr/beanstalk v0.0.0-20180818045031-cae1762e4858
+	github.com/mattn/go-runewidth v0.0.3
+	github.com/nsf/termbox-go v0.0.0-20180819125858-b66b20ab708e
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/kr/beanstalk v0.0.0-20180818045031-cae1762e4858 h1:kkNVQqyYyI0SsW9sOUEAKiLzoJGzW1ZVoYQCUmrAowE=
+github.com/kr/beanstalk v0.0.0-20180818045031-cae1762e4858/go.mod h1:S640fId9Ag4k2hh6Hwwj62pMSZqfMtg/kfKPeAOhET8=
+github.com/mattn/go-runewidth v0.0.3 h1:a+kO+98RDGEfo6asOGMmpodZq4FNtnGP54yps8BzLR4=
+github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/nsf/termbox-go v0.0.0-20180819125858-b66b20ab708e h1:fvw0uluMptljaRKSU8459cJ4bmi3qUYyMs5kzpic2fY=
+github.com/nsf/termbox-go v0.0.0-20180819125858-b66b20ab708e/go.mod h1:IuKpRQcYE1Tfu+oAQqaLisqDeXgjyyltCfsaoYN18NQ=


### PR DESCRIPTION
This allows beanwalker to be compiled outside of a valid GOPATH.

See https://github.com/golang/go/wiki/Modules for more info.